### PR TITLE
chore: remove useless include rule and comma

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -37,10 +37,10 @@
 		"pretty": true,
 		"newLine": "lf",
 		"stripInternal": true,
-		"noUnusedLocals": true,
+		"noUnusedLocals": true
   },
   "include": [
-    "src/**/*", "src/manifest/index.js"
+    "src/**/*"
   ],
   "exclude": [
 		"node_modules"


### PR DESCRIPTION
remove the rule because `src/manifest/index.js` has changed to be `src/manifest.json`
remove the comma for JSON standard does not allow trailing comma