### PR TITLE
Merge dev & prod content-security-policy

### DIFF
--- a/source/manifest.json
+++ b/source/manifest.json
@@ -20,8 +20,7 @@
     "https://*/*"
   ],
 
-  "__dev__content_security_policy": "script-src 'self' 'unsafe-eval'; object-src 'self'",
-  "__prod__content_security_policy": "script-src 'self'; object-src 'self'",
+  "content_security_policy": "script-src 'self'; object-src 'self'",
 
   "__chrome|firefox__author": "abhijithvijayan",
   "__opera__developer": {


### PR DESCRIPTION
As per the discussion [here](https://github.com/abhijithvijayan/wext-manifest-loader/issues/9#issuecomment-631927879), we no longer need a separate `dev`/`prod` version of `content-security-policy` since `unsafe-eval` is not used in `dev` mode anymore.