### PR TITLE
Add webextension environment to eslint

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -8,5 +8,8 @@
 		"no-extend-native": "off",
 		"react/jsx-props-no-spreading": "off",
 		"jsx-a11y/label-has-associated-control": "off"
+	},
+	"env": {
+		"webextensions": true
 	}
 }


### PR DESCRIPTION
This stops eslint from complaining when you use, for example `chrome.runtime.sendMessage`